### PR TITLE
Don't unmarshal JSON if JSON is missing.

### DIFF
--- a/iapclient.go
+++ b/iapclient.go
@@ -200,12 +200,7 @@ func (iap *IAP) getSignerEmail() error {
 		return errors.Wrap(err, "google.FindDefaultCredentials failed")
 	}
 
-	var credJSON credentialJSON
-	if err := json.Unmarshal(credentials.JSON, &credJSON); err != nil {
-		return errors.Wrap(err, "failed to unmarshal Google Default Credential JSON")
-	}
-
-	if credJSON == (credentialJSON{}) {
+	if credentials.JSON == nil {
 		// Looks like we're in GCE - Use the metadata service
 		signerEmail, err := metadataGet("instance/service-accounts/default/email")
 		if err != nil {
@@ -213,6 +208,10 @@ func (iap *IAP) getSignerEmail() error {
 		}
 		iap.signerEmail = signerEmail
 	} else {
+		var credJSON credentialJSON
+		if err := json.Unmarshal(credentials.JSON, &credJSON); err != nil {
+			return errors.Wrap(err, "failed to unmarshal Google Default Credential JSON")
+		}
 		// We're local with JSON file - Get the email directly
 		if credJSON.Type != "service_account" {
 			return fmt.Errorf("IAP auth only works with service_accounts, got %v", credJSON.Type)

--- a/iapclient_test.go
+++ b/iapclient_test.go
@@ -42,7 +42,7 @@ func (c *TransportMock) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func googleFindDefaultCredentialsAppDefaultMock(ctx context.Context, scope ...string) (*google.Credentials, error) {
 	creds := google.Credentials{}
-	creds.JSON = []byte(`{}`)
+	creds.JSON = nil
 	return &creds, nil
 }
 


### PR DESCRIPTION
The Credentials.JSON field is nil if running on Google Cloud Platform as specified in https://godoc.org/golang.org/x/oauth2/google#Credentials.

Tested on AppEngine